### PR TITLE
Added CLI support for Daemonization

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,16 @@ There are a few things worth mentioning when deploying an instance of Lita to He
 
 1. Consider using a service like [Uptime Robot](http://www.uptimerobot.com/) to monitor your Lita instance and keep it from [sleeping](https://blog.heroku.com/archives/2013/6/20/app_sleeping_on_heroku) when running on a free dyno. `/lita/info` is a reliable path to hit from the web to keep it running.
 
+## Running as a Daemon
+
+Lita comes with built in support for daemonization on Unix systems.  The daemon setup will redirect log files and write out a pid file.
+
+To start Lita as a daemon, you can do something like this:
+
+    lita -d -p ~/lita.pid -o ~/lita.stdout.log -e ~/lita.stderr.log
+    
+By default, lita will log the standard streams to `/var/log` and the pid in `/var/run`.  If you specify paths that the lita process is unable to write to, you'll be given a warning and the pid and/or the logs will be written to the current user's home directory.
+
 ## API documentation
 
 Complete documentation for all of Lita's classes and methods can be found at [rdoc.info](http://rdoc.info/gems/lita/frames).

--- a/lib/lita.rb
+++ b/lib/lita.rb
@@ -93,6 +93,7 @@ module Lita
 end
 
 require "lita/util"
+require "lita/daemon"
 require "lita/logger"
 require "lita/user"
 require "lita/source"

--- a/lib/lita/cli.rb
+++ b/lib/lita/cli.rb
@@ -16,10 +16,35 @@ module Lita
       banner: "PATH",
       default: "lita_config.rb",
       desc: "Path to the configuration file to use"
-
+    
+    class_option :daemon,
+      aliases: "-d",
+      banner: "DAEMON",
+      default: false,
+      desc: "Flag to enable daemonization"
+      
+    class_option :pid_file,
+      aliases: "-p",
+      banner: "PID_FILE",
+      default: "/var/run/lita.pid",
+      desc: "Location for pid files when daemonized"
+    
+    class_option :stdout,
+      aliases: "-o",
+      banner: "STDOUT",
+      default: "/var/log/lita.stdout.log",
+      desc: "Where to direct stdout"
+      
+    class_option :stderr,
+      aliases: "-e",
+      banner: "STDERR",
+      default: "/var/log/lita.stderr.log",
+      desc: "Where to direct stderr"
+      
     desc "start", "Starts Lita"
     def start
       Bundler.require
+      setup_daemon if options[:daemon]
       Lita.run(options[:config])
     end
 
@@ -27,5 +52,22 @@ module Lita
     def new(name = "lita")
       directory "skeleton", name
     end
+    
+    private
+    
+    def setup_daemon
+      # Rename the process so it's obvious in process lists
+      $0 = "lita"
+
+      # Spawn a deamon for our bot
+      Lita::Daemon.daemonize(:pid_file => options[:pid_file], :stdout_file => options[:stdout], :stderr_file => options[:stderr])
+
+      # Set up signals for our daemon so it knows how to exit
+      Signal.trap("QUIT") { exit }
+      %w(HUP INT).each do |signal|
+        Signal.trap(signal, "IGNORE")
+      end
+    end
+    
   end
 end

--- a/lib/lita/daemon.rb
+++ b/lib/lita/daemon.rb
@@ -1,0 +1,89 @@
+module Lita
+  class Daemon
+    
+    ForkingException = Class.new(Exception)
+    
+    # Get us ready for daemonization
+    def self.daemonize(options = { })
+      # Kill the original parent process if we can fork
+      case fork
+      when nil
+        # Break away from the terminal, become a new process & group leader
+        Process.setsid
+        start(fork, options)
+      when -1
+        raise ForkingException, "Forking failed for some reason.  Does this OS support forking?"
+      else
+        exit
+      end
+    end
+    
+    private
+    
+    # Starts the final form of the daemon, writes out a pid, redirects logs, etc.
+    def self.start(pid, options = { })
+      pid_file    = options[:pid_file] || "/tmp/lita.pid"
+      stdout_file = options[:stdout_file] || "/tmp/lita.stdout.log"
+      stderr_file = options[:stderr_file] || "/tmp/lita.stderr.log"
+      
+      case pid
+      when nil
+        # nil for the fork value means we're in the child process
+        redirect_streams(stdout_file, stderr_file)
+      when -1
+        # Couldn't fork for some reason - usually OS related
+        raise ForkingException, "Forking failed for some reason.  Does this OS support forking?"
+      else
+        # Try to kill any existing processes, write pid, exit
+        write_pid(pid, pid_file) if kill(pid, pid_file)
+        exit
+      end
+    end
+    
+    # Attempts to write the pid of the forked process to the pid file
+    def self.write_pid(pid, pid_file)
+      File.open(pid_file, "w") { |f| f.write(pid) }
+    rescue Errno::EPERM, Errno::EACCES
+      safe_pid_location = File.join(Dir.home, "lita.pid")
+      warn "Unable to write pid to: #{pid_file}.  Writing pid to #{safe_pid_location} instead."
+      File.open(safe_pid_location, "w") { |f| f.write(pid) }
+    rescue ::Exception => e
+      $stderr.puts "Unable to write pid file: unexpected #{e.class}: #{e}"
+      Process.kill("QUIT", pid)
+    end
+
+    # Attempts to kill any existing processes for rolling restarts
+    def self.kill(pid, pidfile)
+      existing_pid = open(pidfile).read.strip.to_i
+      Process.kill("QUIT", existing_pid)
+      true
+    rescue Errno::ESRCH, Errno::ENOENT
+      true
+    rescue Errno::EPERM
+      $stderr.puts "Permission denied trying to kill #{existing_pid}: Errno::EPERM"
+      false
+    rescue ::Exception => e
+      $stderr.puts "Unexpected #{e.class}: #{e}"
+      false
+    end
+
+    # Redirect the stdout and stderr to log files
+    def self.redirect_streams(outfile, errfile)
+      redirect_stream($stdin, '/dev/null', 'stdin', mode: 'r', sync: false)
+      redirect_stream($stdout, outfile, 'stdout')
+      redirect_stream($stderr, errfile, 'stderr')
+    end
+    
+    def self.redirect_stream(stream, location, stream_name, mode: 'a', sync: true)
+      log_file = File.new(location, mode)
+    rescue Errno::EPERM, Errno::EACCESS
+      default_location = File.join(Dir.home, "lita.#{stream_name}.log")
+      warn "Unable to write to: #{location}. Writing to `#{default_location}' instead."
+      log_file = File.new(default_location, mode)
+    ensure
+      stream.reopen(log_file)
+      stream.sync = sync
+    end
+    
+  end
+end


### PR DESCRIPTION
This branch adds a daemonizer for Lita.  Here's how it works...

If you supply a -d flag, Lita will do the following:
1. The process will fork itself.
2. The parent will attempt to write the forked process's pid if the existing pid file is missing, empty, or the process can be killed.
3. The parent process quits.
4. The forked process will redirect its log files (pid is "nil" in the child process after the fork).
5. The process then ignores HUP and INT while it runs (By default, Ruby will exit.  Most web servers use these signals for config reloads or something along those lines).

There are additional flags to redirect the log files to locations of your choosing.

I've been running this in production for about a week now and it's been rock solid on CentOS.  I also have a simple `init.d` script for CentOS that will allow you to control Lita but I have not included it at this time.

This is only the second daemonizer I've written so if there are any questions or concerns I'm all ears.  I will admit though, that I'm not entirely sure how/what to test for this feature with RSpec since it's mostly lower level Unix code.  I guess at the very least, it might be good to mention it in the README file.
