### PR TITLE
Only attempt to kill the process if the PID file exists.

### DIFF
--- a/lib/lita/daemon.rb
+++ b/lib/lita/daemon.rb
@@ -36,7 +36,7 @@ FATAL
 
     # Call the appropriate method depending on kill mode.
     def handle_existing_process
-      if @kill_existing
+      if @kill_existing && File.exists?(@pid_path)
         kill_existing_process
       else
         ensure_not_running


### PR DESCRIPTION
Thanks for your work on Lita!

I'd like to be able to consistently pass the `-k` option without having to worry about whether a process is already running or not. Currently, this fails as we try and read a non-existent file:

```
$ bundle exec lita -dk
~/.gem/ruby/2.0.0/gems/lita-2.6.0/lib/lita/daemon.rb:48:in `read': No such file or directory - ~/lita.pid (Errno::ENOENT)
  from ~/.gem/ruby/2.0.0/gems/lita-2.6.0/lib/lita/daemon.rb:48:in `kill_existing_process'
  from ~/.gem/ruby/2.0.0/gems/lita-2.6.0/lib/lita/daemon.rb:40:in `handle_existing_process'
  from ~/.gem/ruby/2.0.0/gems/lita-2.6.0/lib/lita/daemon.rb:18:in `daemonize'
  from ~/.gem/ruby/2.0.0/gems/lita-2.6.0/lib/lita/cli.rb:62:in `start'
  from ~/.gem/ruby/2.0.0/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
  from ~/.gem/ruby/2.0.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
  from ~/.gem/ruby/2.0.0/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
  from ~/.gem/ruby/2.0.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
  from ~/.gem/ruby/2.0.0/gems/lita-2.6.0/bin/lita:6:in `<top (required)>'
  from ~/.gem/ruby/2.0.0/bin/lita:23:in `load'
  from ~/.gem/ruby/2.0.0/bin/lita:23:in `<main>'
```

It seems the most sensible thing to do here is ensure the file exists before trying to read it. I didn't see anywhere that you were testing the daemon behavior, so I didn't add any tests. Let me know if you think we need them or if you have any feedback!
