### PR TITLE
Add Guard word support to commands

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ CaseEquality:
   Enabled: false
 ClassLength:
   Enabled: false
+CyclomaticComplexity:
+  Max: 8
 Documentation:
   Enabled: false
 EndAlignment:
@@ -14,6 +16,8 @@ LineLength:
   Max: 100
 MethodLength:
   Enabled: false
+ParameterLists:
+  Max: 6
 RescueException:
   Enabled: false
 SignalException:

--- a/lib/lita/config.rb
+++ b/lib/lita/config.rb
@@ -62,6 +62,8 @@ module Lita
         config.robot.locale = I18n.locale
         config.robot.log_level = :info
         config.robot.admins = nil
+        config.robot.guard_name = "GUARD"
+        config.robot.guard_word = "foobar"
       end
     end
 

--- a/lib/lita/message.rb
+++ b/lib/lita/message.rb
@@ -29,6 +29,10 @@ module Lita
       name_pattern = "#{name_pattern}|#{Regexp.escape(@robot.alias)}" if @robot.alias
 
       @command = !!@body.sub!(/^\s*@?(?:#{name_pattern})[:,]?\s*/i, "")
+
+      guard_name_pattern = Regexp.escape(Lita.config.robot.guard_name)
+      guard_word_pattern = Regexp.escape(Lita.config.robot.guard_word)
+      @guarded = !!@body.sub!(/\s#{guard_name_pattern}=#{guard_word_pattern}$/i, "")
     end
 
     # An array of arguments created by shellsplitting the message body, as if
@@ -56,6 +60,18 @@ module Lita
     # @return [Boolean] +true+ if the message was a command, +false+ if not.
     def command?
       @command
+    end
+
+    # Marks the message as having a guard ("lita do something GUARD=word")
+    # @return [void]
+    def guarded!
+      @guarded = true
+    end
+
+    # A boolean representing whether or not the message had a guard.
+    # @return [Boolean] +true+ if the message had a guard, +false+ if not.
+    def guarded?
+      @guarded && @command
     end
 
     # An array of matches against the message body for the given {::Regexp}.

--- a/spec/lita/message_spec.rb
+++ b/spec/lita/message_spec.rb
@@ -69,6 +69,43 @@ describe Lita::Message do
     end
   end
 
+  describe "#guarded!" do
+    it "marks a command as guarded" do
+      subject.command!
+      subject.guarded!
+      expect(subject).to be_guarded
+    end
+
+    it "does not mark a message as guarded" do
+      subject.guarded!
+      expect(subject).not_to be_guarded
+    end
+  end
+
+  describe "#guarded?" do
+    it "is true when the command has a guard at the end" do
+      subject = described_class.new(
+        robot,
+        "#{robot.mention_name}: testing GUARD=foobar",
+        "Carl"
+      )
+      expect(subject).to be_guarded
+    end
+
+    it "is false when the message has a guard at the end but is not a command" do
+      subject = described_class.new(
+        robot,
+        "some testing message GUARD=foobar",
+        "Carl"
+      )
+      expect(subject).not_to be_guarded
+    end
+
+    it "is false when the message does not have a guard at the end" do
+      expect(subject).not_to be_guarded
+    end
+  end
+
   describe "#user" do
     it "delegates to #source" do
       expect(subject.source).to receive(:user)

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -60,6 +60,7 @@ en:
         remove the PID file and then start Lita.
       kill_failure: "Failed to kill existing Lita process %{pid}."
     handler:
+      guard_required: "That command requires %{guard_name}=%{guard_word} appended to the end"
       name_required: Handlers that are anonymous classes must define self.name.
       dispatch: "Dispatching message to %{handler}#%{method}."
       exception: |


### PR DESCRIPTION
This is a proposal to add a setting to routes (commands specifically), to allow them to require a guard word.  The use case is to provide an extra layer of defense for commands. In many chat clients, "lita do_something_scary" is one up-arrow away in history.

I'm sending this PR now as a functional draft to get feedback.  In particular, I don't know that I like responding to the message in the route_applies? function, but I don't see a better place to put it without more significant refactoring.  (I also had to adjust two Rubocop values, which also would have required more in-depth changes.)

Example current usage:

```
Lita > something
Lita > something GUARD=foobar
Lita > lita scary_command
That command requires GUARD=foobar appended to the end
Lita > lita scary_command GUARD=foo
That command requires GUARD=foobar appended to the end
Lita > lita scary_command GUARD=foobar
(Does scary things)
```

One thing this PR is lacking in particular right now, is a rotating guard word.  Without it, it's rather easy to still get in trouble.  I'm probably going to set it to use an array of words, selected on a deterministic rotation.  Something like:

``` ruby
guard_words = ['foo', 'bar', 'baz']
guard_frequency = daily
```

To enable "GUARD=foo" on Monday, "GUARD=bar" on Tuesday, etc.  Any feedback would be appreciated!
