### PR TITLE
Add Handler#config and Handler#log.

### DIFF
--- a/lib/lita/handler.rb
+++ b/lib/lita/handler.rb
@@ -206,6 +206,12 @@ module Lita
       Thread.new { Timer.new(interval: interval, &block).start }
     end
 
+    # The handler's config object.
+    # @return [Lita::Config] The handler's config object.
+    def config
+      Lita.config.handlers[self.class.namespace]
+    end
+
     # Invokes the given block repeatedly, waiting the given number of seconds between each
     # invocation.
     # @param interval [Integer] The number of seconds to wait before each invocation of the block.
@@ -225,6 +231,12 @@ module Lita
     def http(options = {}, &block)
       options = default_faraday_options.merge(options)
       Faraday::Connection.new(nil, options, &block)
+    end
+
+    # The Lita logger.
+    # @return [Lita::Logger] The Lita logger.
+    def log
+      Lita.logger
     end
 
     # @see .translate

--- a/spec/lita/handler_spec.rb
+++ b/spec/lita/handler_spec.rb
@@ -22,6 +22,10 @@ describe Lita::Handler, lita: true do
       on :connected, :greet
       on :some_hook, :test_payload
 
+      def self.default_config(config)
+        config.foo = "bar"
+      end
+
       def foo(response)
       end
 
@@ -171,6 +175,19 @@ describe Lita::Handler, lita: true do
     end
   end
 
+  describe "#config" do
+    before { Lita.register_handler(handler_class) }
+    subject { handler_class.new(robot) }
+
+    it "returns a Lita config" do
+      expect(subject.config).to be_a(Lita::Config)
+    end
+
+    it "contains the handler's config settings" do
+      expect(subject.config.foo).to eq("bar")
+    end
+  end
+
   describe "#http" do
     it "returns a Faraday connection" do
       expect(subject.http).to be_a(Faraday::Connection)
@@ -191,6 +208,12 @@ describe Lita::Handler, lita: true do
     it "passes blocks on to Faraday" do
       connection = subject.http { |builder| builder.response :logger }
       expect(connection.builder.handlers).to include(Faraday::Response::Logger)
+    end
+  end
+
+  describe "#log" do
+    it "returns the Lita logger" do
+      expect(subject.log).to eq(Lita.logger)
     end
   end
 


### PR DESCRIPTION
This adds the Lita::Handler#config and Lita::Handler#log methods from [railsmachine/lita-ext](https://github.com/railsmachine/lita-ext) as discussed on the Lita mailing list.
