### PR TITLE
Treat message.body as UTF-8 in RouteValidator

### DIFF
--- a/lib/lita/route_validator.rb
+++ b/lib/lita/route_validator.rb
@@ -47,7 +47,7 @@ module Lita
 
     # Message must match the pattern
     def matches_pattern?(route, message)
-      route.pattern === message.body
+      route.pattern === message.body.force_encoding("UTF-8")
     end
 
     # Allow custom route hooks to reject the route

--- a/spec/lita/handler_spec.rb
+++ b/spec/lita/handler_spec.rb
@@ -40,6 +40,7 @@ describe Lita::Handler, lita: true do
       route(/danger/, :danger)
       route(/guard/, :guard, guard: true)
       route(/trigger route hook/, :trigger_route_hook, data: :foo)
+      route(/寿司/, :sushi)
 
       on :connected, :greet
       on :some_hook, :test_payload
@@ -65,6 +66,9 @@ describe Lita::Handler, lita: true do
       end
 
       def trigger_route_hook(_response)
+      end
+
+      def sushi(_response)
       end
 
       def greet(payload)
@@ -107,6 +111,12 @@ describe Lita::Handler, lita: true do
     it "routes a matching message to the supplied method" do
       allow(message).to receive(:body).and_return("bar")
       expect_any_instance_of(handler_class).to receive(:foo)
+      handler_class.dispatch(robot, message)
+    end
+
+    it "routes a matching non-ascii message to the supplied method" do
+      allow(message).to receive(:body).and_return("寿司".force_encoding("ASCII-8BIT"))
+      expect_any_instance_of(handler_class).to receive(:sushi)
       handler_class.dispatch(robot, message)
     end
 


### PR DESCRIPTION
After updating lita from v3.2.0 to v3.3.0, I got `Encoding::CompatibilityError` with ShellAdapter.
So, I tried to fix it.

Here is my chatbot repository:  [fukayatsu/twitter-fkbot at lita-v330](https://github.com/fukayatsu/twitter-fkbot/tree/lita-v330)

```
fk82% lita
Type "exit" or "quit" to end the session.
lita > lita img me sushi
http://www.zippys.com/wp-content/uploads/2013/02/SushiPlatter-web.jpg
lita > lita 寿司
/Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/route_validator.rb:50:in `===': incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string) (Encoding::CompatibilityError)
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/route_validator.rb:50:in `matches_pattern?'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/route_validator.rb:29:in `call'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/handler.rb:166:in `route_applies?'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/handler.rb:65:in `block in dispatch'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/handler.rb:64:in `each'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/handler.rb:64:in `dispatch'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/robot.rb:39:in `block in receive'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/2.1.0/set.rb:263:in `each_key'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/2.1.0/set.rb:263:in `each'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/robot.rb:39:in `receive'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/adapters/shell.rb:70:in `block in run_loop'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/adapters/shell.rb:61:in `loop'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/adapters/shell.rb:61:in `run_loop'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/adapters/shell.rb:15:in `run'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/robot.rb:47:in `run'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita.rb:141:in `run'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/lib/lita/cli.rb:75:in `start'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/lita-3.3.0/bin/lita:6:in `<top (required)>'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bin/lita:23:in `load'
    from /Users/fukayatsu/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bin/lita:23:in `<main>'
```
