### PR TITLE
Force encoding input read via Readline in shell adapter

### DIFF
--- a/lib/lita/adapters/shell.rb
+++ b/lib/lita/adapters/shell.rb
@@ -54,7 +54,10 @@ module Lita
       end
 
       def read_input
-        Readline.readline("#{robot.name} > ", true)
+        input = Readline.readline("#{robot.name} > ", true)
+        # Input read via rb-readline will always be encoded as US-ASCII.
+        # @see https://github.com/luislavena/rb-readline/blob/master/lib/readline.rb#L1
+        input.force_encoding(Encoding.default_external)
       end
 
       def run_loop


### PR DESCRIPTION
This fixes Encoding::CompatibilityError with non-ascii caractors when using the shell adapter.

from: [#57(comment)](https://github.com/jimmycuadra/lita/pull/57#issuecomment-47896265)
