### PR TITLE
Use fake redis for plugin specs

### DIFF
--- a/templates/plugin/gemspec.tt
+++ b/templates/plugin/gemspec.tt
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rspec", ">= 3.0.0"
+  spec.add_development_dependency "fakeredis"
   <%- if config[:coveralls] -%>
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "coveralls"

--- a/templates/plugin/spec/spec_helper.tt
+++ b/templates/plugin/spec/spec_helper.tt
@@ -10,6 +10,7 @@ SimpleCov.start { add_filter "/spec/" }
 <%- end -%>
 require "<%= config[:gem_name] %>"
 require "lita/rspec"
+require "fakeredis/rspec"
 
 # A compatibility mode is provided for older plugins upgrading from Lita 3. Since this plugin
 # was generated with Lita 4, the compatibility mode should be left disabled.


### PR DESCRIPTION
Seriously, it's either that or meaningful error message when Redis is not running.
