### PR TITLE
Run chat handlers in separate threads

### DIFF
--- a/lib/lita/handler/chat_router.rb
+++ b/lib/lita/handler/chat_router.rb
@@ -70,7 +70,11 @@ module Lita
         routes.map do |route|
           next unless route_applies?(route, message, robot)
           log_dispatch(route)
-          dispatch_to_route(route, robot, message)
+          if Lita.test_mode?
+            dispatch_to_route(route, robot, message)
+          else
+            Thread.start { dispatch_to_route(route, robot, message) }
+          end
           true
         end.any?
       end


### PR DESCRIPTION
First I don't really expect this to be merged, it's more to have your opinion on the matter.

My issue is that from my understanding of the code, even though the http routes are executed in puma threads, the chat routes are all executed synchronously in the main thread (I might have missed something though).

This can easily be tested:
```ruby
class FastAndSlow < Lita::Handler
  route 'slow' do |response|
    sleep 3
    response.reply("Slow!")
  end

  route 'fast' do |response|
    response.reply("Fast!")
  end
end
```

Then in the chat it will look like this:
```
me> lita fast
lita> Fast!
me> lita slow
me> lita fast
lita> Slow!
lita> Fast!
```

After the patch
```
me> lita fast
lita> Fast!
me> lita slow
me> lita fast
lita> Fast!
lita> Slow!
```

So both code review and experimentation tells me only a single chat handler can be possibly running at once.

Which is problematic when you shell out to slow sub processes or call slow HTTP endpoints.

I quickly experimented that patch and it seems to works fine, but our Lita instance is still quite small, so do you think we might run into much troubles with that patch? Since the HTTP handlers are already threaded I assume not, but I'd love a second opinion.