### PR TITLE
Upload file abstraction

### DIFF
--- a/lib/lita/adapter.rb
+++ b/lib/lita/adapter.rb
@@ -81,6 +81,13 @@ module Lita
     # @return [void]
     # @abstract This should be implemented by the adapter.
 
+    # @!method send_file(target, filepath)
+    # Upload file to a user or room.
+    # @param target [Lita::Source] The user or room to send messages to.
+    # @param filepath [String] Path to file.
+    # @return [void]
+    # @abstract This should be implemented by the adapter.
+
     # @!method set_topic(target, topic)
     # Sets the topic for a room.
     # @param target [Lita::Source] The room to change the topic for.
@@ -92,7 +99,7 @@ module Lita
     # Performs any clean up necessary when disconnecting from the chat service.
     # @return [void]
     # @abstract This should be implemented by the adapter.
-    [:join, :part, :run, :send_messages, :set_topic, :shut_down].each do |method|
+    [:join, :part, :run, :send_messages, :send_file, :set_topic, :shut_down].each do |method|
       define_method(method) do |*_args|
         Lita.logger.warn(I18n.t("lita.adapter.method_not_implemented", method: method))
       end

--- a/lib/lita/message.rb
+++ b/lib/lita/message.rb
@@ -90,5 +90,12 @@ module Lita
     def reply_with_mention(*strings)
       @robot.send_messages_with_mention(source, *strings)
     end
+
+    # Replies by sending the given strings back to the source of the message.
+    # @param filepath [String] Path to the file to send back.
+    # @return [void]
+    def reply_with_file(filepath)
+      @robot.send_file(source, filepath)
+    end
   end
 end

--- a/lib/lita/response.rb
+++ b/lib/lita/response.rb
@@ -25,10 +25,12 @@ module Lita
     #   @see Lita::Message#reply_privately
     # @!method reply_with_mention
     #   @see Lita::Message#reply_with_mention
+    # @!method reply_with_file
+    #   @see Lita::Message#reply_with_file
     # @!method user
     #   @see Lita::Message#user
     def_delegators :message, :args, :reply, :reply_privately,
-      :reply_with_mention, :user, :command?
+      :reply_with_mention, :reply_with_file, :user, :command?
 
     # @param message [Lita::Message] The incoming message.
     # @param pattern [Regexp] The pattern the incoming message matched.

--- a/lib/lita/robot.rb
+++ b/lib/lita/robot.rb
@@ -118,6 +118,16 @@ module Lita
     end
     alias_method :send_message_with_mention, :send_messages_with_mention
 
+    # Sends file to a user or room.
+    # @param target [Lita::Source] The user or room to send to. If the Source
+    #   has a room, it will choose the room. Otherwise, it will send to the
+    #   user.
+    # @param filepath [String] Path to file to upload.
+    # @return [void]
+    def send_file(target, filepath)
+      adapter.send_file(target, filepath)
+    end
+
     # Sets the topic for a chat room.
     # @param target [Lita::Source] A source object specifying the room.
     # @param topic [String] The new topic message to set.

--- a/spec/lita/message_spec.rb
+++ b/spec/lita/message_spec.rb
@@ -106,4 +106,12 @@ describe Lita::Message do
       subject.reply_with_mention("foo", "bar")
     end
   end
+
+  describe "#reply_with_file" do
+    it "sends filepath back to the source through the robot" do
+      filepath = "/path/to/file"
+      expect(robot).to receive(:send_file).with(source, filepath)
+      subject.reply_with_file(filepath)
+    end
+  end
 end

--- a/spec/lita/response_spec.rb
+++ b/spec/lita/response_spec.rb
@@ -12,6 +12,12 @@ describe Lita::Response do
     end
   end
 
+  it "delegates :reply_with_file to #message" do
+    filepath = "/path/to/file"
+    expect(message).to receive(:reply_with_file).with(filepath)
+    subject.reply_with_file(filepath)
+  end
+
   describe "#matches" do
     it "matches the pattern against the message" do
       expect(message).to receive(:match).with(subject.pattern)


### PR DESCRIPTION
I was inspired by your comment on https://github.com/kenjij/lita-slack/issues/20.

I am also working on a way of to get file uploading working with Lita + Slack, although it isn't very simple because Slack's real-time API does not support it.

I kept it very simple, all the robot passes the filepath down to the adapter and it is responsible for taking care of the upload. The only issue is that is doesn't support any metadata. Some "networks" allow you to set metadata such as the tile, initial comment. 

Let me know if you would like me to change anything. 
