### PR TITLE
Add post_route and rescue_route hooks

### DIFF
--- a/lib/lita/handler/chat_router.rb
+++ b/lib/lita/handler/chat_router.rb
@@ -102,7 +102,11 @@ module Lita
         robot.hooks[:trigger_route].each { |hook| hook.call(response: response, route: route) }
         handler = new(robot)
         route.callback.call(handler, response)
+        robot.hooks[:post_route].each { |hook| hook.call(response: response, route: route) }
       rescue => error
+        robot.hooks[:rescue_route].each do |hook|
+          hook.call(response: response, route: route, error: error)
+        end
         log_error(robot, error)
       end
 


### PR DESCRIPTION
I think a post_route hook is useful for things like log all command executions and an error_route hook would be useful for automatically catching all unhandled errors to display something back on the chat (instead of failing silently).

If you confirm me you are probably going to merge this, I'll create test for them.

Thanks for your great work!
