### PR TITLE
Avoids an issue where bad metadata breaks Redis.hmset

### DIFF
--- a/lib/lita/room.rb
+++ b/lib/lita/room.rb
@@ -15,7 +15,7 @@ module Lita
       # @return [Room] The room.
       def create_or_update(id, metadata = {})
         existing_room = find_by_id(id)
-        metadata = Util.stringify_keys(metadata)
+        metadata = Util.strip_blanks(Util.stringify_keys(metadata))
         metadata = existing_room.metadata.merge(metadata) if existing_room
         room = new(id, metadata)
         room.save

--- a/lib/lita/user.rb
+++ b/lib/lita/user.rb
@@ -92,7 +92,7 @@ module Lita
     # @option metadata [String] name (id) The user's display name.
     def initialize(id, metadata = {})
       @id = id.to_s
-      @metadata = Util.stringify_keys(metadata)
+      @metadata = Util.strip_blanks(Util.stringify_keys(metadata))
       @name = @metadata["name"] || @id
       ensure_name_metadata_set
     end

--- a/lib/lita/util.rb
+++ b/lib/lita/util.rb
@@ -12,6 +12,16 @@ module Lita
         result
       end
 
+      def strip_blanks(hash)
+        hash.delete_if do |_key, value|
+          if value.respond_to?(:empty?)
+            value.empty?
+          else
+            value.to_s.strip == ""
+          end
+        end
+      end
+
       # Transforms a camel-cased string into a snaked-cased string. Taken from +ActiveSupport.+
       # @param camel_cased_word [String] The word to transform.
       # @return [String] The transformed word.

--- a/spec/lita/room_spec.rb
+++ b/spec/lita/room_spec.rb
@@ -130,5 +130,13 @@ describe Lita::Room, lita: true do
         expect(subject.metadata["name"]).to eq("1")
       end
     end
+    context "with metadata that flattens in a way that breaks hmset" do
+      subject { described_class.create_or_update(1, name: "foo", fields: [], foo: nil) }
+      it "does not blow up on hmset" do
+        expect do
+          subject.save
+        end.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/lita/user_spec.rb
+++ b/spec/lita/user_spec.rb
@@ -109,21 +109,31 @@ describe Lita::User, lita: true do
   end
 
   describe "#save" do
-    subject { described_class.new(1, name: "Carl", mention_name: "carlthepug") }
+    context "normal metadata" do
+      subject { described_class.new(1, name: "Carl", mention_name: "carlthepug") }
 
-    it "saves an ID to name mapping for the user in Redis" do
-      subject.save
-      expect(described_class.redis.hgetall("id:1")).to include("name" => "Carl")
+      it "saves an ID to name mapping for the user in Redis" do
+        subject.save
+        expect(described_class.redis.hgetall("id:1")).to include("name" => "Carl")
+      end
+
+      it "saves a name to ID mapping for the user in Redis" do
+        subject.save
+        expect(described_class.redis.get("name:Carl")).to eq("1")
+      end
+
+      it "saves a mention name to ID mapping for the user in Redis" do
+        subject.save
+        expect(described_class.redis.get("mention_name:carlthepug")).to eq("1")
+      end
     end
-
-    it "saves a name to ID mapping for the user in Redis" do
-      subject.save
-      expect(described_class.redis.get("name:Carl")).to eq("1")
-    end
-
-    it "saves a mention name to ID mapping for the user in Redis" do
-      subject.save
-      expect(described_class.redis.get("mention_name:carlthepug")).to eq("1")
+    context "with metadata that flattens in a way that breaks hmset" do
+      subject { described_class.new(1, name: "Carl", mention_name: "carlthepug", fields: []) }
+      it "does not blow up on hmset" do
+        expect do
+          subject.save
+        end.not_to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
Since the metadata isn't vetted in any way, and it's being totally flattened, it's possible that blank values in the original hash result in  an argument list with odd numbers of values, which causes hmset to
raise an exception.

I can't explain why this is happening, but it definitely happens on our Slack.  Brand new install, latest lita, the bot can't connect because someone had the value `:fields => []` in the metadata coming out of Slack.   Since there's no other sanity-checks, this PR seems reasonable, but I don't know the codebase to know if this is the right way to solve this.