### PR TITLE
bug when user key/value is an array

### DIFF
--- a/lib/lita/user.rb
+++ b/lib/lita/user.rb
@@ -21,7 +21,7 @@ module Lita
       def create(id, metadata = {})
         existing_user = find_by_id(id)
         metadata = Util.stringify_keys(metadata)
-        matadata = Util.stringify_values(metadata)
+        metadata = Util.stringify_values(metadata)
         metadata = existing_user.metadata.merge(metadata) if existing_user
         user = new(id, metadata)
         user.save

--- a/lib/lita/user.rb
+++ b/lib/lita/user.rb
@@ -21,6 +21,7 @@ module Lita
       def create(id, metadata = {})
         existing_user = find_by_id(id)
         metadata = Util.stringify_keys(metadata)
+        matadata = Util.stringify_values(metadata)
         metadata = existing_user.metadata.merge(metadata) if existing_user
         user = new(id, metadata)
         user.save

--- a/lib/lita/util.rb
+++ b/lib/lita/util.rb
@@ -11,6 +11,18 @@ module Lita
         hash.each_key { |key| result[key.to_s] = hash[key] }
         result
       end
+      
+      def stringify_values(hash)
+        result = {}
+        hash.each_key { |key|
+          if hash[key].is_a?([].class)
+            result[key] = hash[key].to_s
+          else
+            result[key] = hash[key]
+          end
+        }
+        result
+      end
 
       # Transforms a camel-cased string into a snaked-cased string. Taken from +ActiveSupport.+
       # @param camel_cased_word [String] The word to transform.


### PR DESCRIPTION
when a user object is created in redis with hmset it flattens the user into an array
if any of key/value for the user is an array, it flattens into an invalid HMSET
