### PR TITLE
Update Simplecov formatter syntax

### DIFF
--- a/lita.gemspec
+++ b/lita.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rspec", ">= 3.0.0"
-  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov", ">=0.9.2"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rubocop", "~> 0.33.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "simplecov"
 require "coveralls"
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]

--- a/templates/plugin/spec/spec_helper.tt
+++ b/templates/plugin/spec/spec_helper.tt
@@ -1,7 +1,7 @@
 <%- if config[:coveralls] -%>
 require "simplecov"
 require "coveralls"
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]


### PR DESCRIPTION
In https://github.com/colszowka/simplecov/pull/317 Simplecov changed how they specify multiple formatters.  This change updates to the newer syntax.