### PR TITLE
user: Check to see if fields item in user metadata is an empty array

### DIFF
--- a/lib/lita/user.rb
+++ b/lib/lita/user.rb
@@ -110,6 +110,12 @@ module Lita
     def save
       mention_name = metadata[:mention_name] || metadata["mention_name"]
 
+      # if adapter returns an empty array then the flatten call below will
+      # misalign the redis.hmset call, causing the bot to fail startup
+      if metadata['fields'] && metadata['fields'].size == 0
+        metadata.delete 'fields'
+      end
+
       redis.pipelined do
         redis.hmset("id:#{id}", *metadata.to_a.flatten)
         redis.set("name:#{name}", id)


### PR DESCRIPTION
if adapter returns an empty array then the flatten call below will misalign the redis.hmset call, causing the bot to fail startup.

We are using `lita-slack` and my fields array was my Skype ID.   

We added a new employee and then our bot failed to start, do to this bug.   I am not sure if this is the proper fix or not, but this works :)