### PR TITLE
Allow adapters to attach data to Lita::Message

### DIFF
--- a/lib/lita/message.rb
+++ b/lib/lita/message.rb
@@ -13,6 +13,10 @@ module Lita
     # @return [Source] The message source.
     attr_reader :source
 
+    # A hash of arbitrary data that can be populated by Lita adapters and extensions.
+    # @return [Hash] The extension data.
+    attr_reader :extensions
+
     # @!method user
     #   The user who sent the message.
     #   @return [User] The user.
@@ -36,6 +40,7 @@ module Lita
       @robot = robot
       @body = body
       @source = source
+      @extensions = {}
 
       name_pattern = "@?#{Regexp.escape(@robot.mention_name)}[:,]?\\s+"
       alias_pattern = "#{Regexp.escape(@robot.alias)}\\s*" if @robot.alias

--- a/spec/lita/message_spec.rb
+++ b/spec/lita/message_spec.rb
@@ -21,6 +21,14 @@ describe Lita::Message do
     expect(subject.source).to eq(source)
   end
 
+  describe "#extensions" do
+    it "can be populated with arbitrary data" do
+      subject.extensions[:foo] = :bar
+
+      expect(subject.extensions[:foo]).to eq(:bar)
+    end
+  end
+
   describe "#args" do
     it "returns an array of the 2nd through nth word in the message" do
       subject = described_class.new(robot, "args foo bar", source)


### PR DESCRIPTION
Includes some basic tests, rdoc comments, and a version bump.

Proposing this implementation of functionality to allow for [lita-slack#73 (Add a reaction to a message)](https://github.com/kenjij/lita-slack/issues/73), which requires Slack specific data provided to the adapter.