### PR TITLE
Attempt to find a room by name with leading #s stripped

### DIFF
--- a/lib/lita/room.rb
+++ b/lib/lita/room.rb
@@ -34,7 +34,7 @@ module Lita
       # @param name [String] The room's name.
       # @return [Room, nil] The room or +nil+ if no such room is known.
       def find_by_name(name)
-        id = redis.get("name:#{name}")
+        id = redis.get("name:#{name}") || redis.get("name:#{name.sub(/^#+/, '')}")
         find_by_id(id) if id
       end
 

--- a/lib/lita/room.rb
+++ b/lib/lita/room.rb
@@ -34,7 +34,7 @@ module Lita
       # @param name [String] The room's name.
       # @return [Room, nil] The room or +nil+ if no such room is known.
       def find_by_name(name)
-        id = redis.get("name:#{name}") || redis.get("name:#{name.sub(/^#+/, '')}")
+        id = redis.get("name:#{name}") || redis.get("name:#{name.to_s.sub(/^#+/, '')}")
         find_by_id(id) if id
       end
 

--- a/spec/lita/room_spec.rb
+++ b/spec/lita/room_spec.rb
@@ -47,6 +47,10 @@ describe Lita::Room, lita: true do
       it "is found by name" do
         expect(described_class.find_by_name("foo").id).to eq("1")
       end
+
+      it "is found even if the argument contains a leading hash character" do
+        expect(described_class.find_by_name("#foo").id).to eq("1")
+      end
     end
 
     context "when no matching room exists" do


### PR DESCRIPTION
After testing an in-progress handler I'm writing on Slack, I've
discovered that Room.find_by_name will not find a Slack channel if the
given string contains the leading #. With this change, the method tries
again with the leading # stripped.