### PR TITLE
Fetch room data in message source

### DIFF
--- a/lib/lita/source.rb
+++ b/lib/lita/source.rb
@@ -42,7 +42,7 @@ module Lita
       case room
       when String
         @room = room
-        @room_object = Room.new(room)
+        @room_object = Room.find_by_id(room) || Room.new(room)
       when Room
         @room = room.id
         @room_object = room

--- a/spec/lita/source_spec.rb
+++ b/spec/lita/source_spec.rb
@@ -49,6 +49,15 @@ describe Lita::Source do
     it "sets #room_object to a Lita::Room with the string as its ID" do
       expect(subject.room_object).to eq(Lita::Room.new(room))
     end
+
+    context "room exists in database" do
+      let(:name) { "example" }
+
+      it "finds room by its ID" do
+        Lita::Room.create_or_update(room, name: name)
+        expect(subject.room_object.name).to eq(name)
+      end
+    end
   end
 
   it "requires either a user or a room" do


### PR DESCRIPTION
Rather than just initializing a room object, this will ensure the room belonging to a message `Source` is fetching from the database. This provides access to room metadata that you would otherwise have to look up after the fact.

See discussion https://github.com/litaio/lita/commit/f507bb0b02940b35b1d9ce3218714a0a5046c460#commitcomment-15466157

cc @jimmycuadra 