### PR TITLE
Pass message that caused exception to error handler

### DIFF
--- a/lib/lita/handler/chat_router.rb
+++ b/lib/lita/handler/chat_router.rb
@@ -103,7 +103,7 @@ module Lita
         handler = new(robot)
         route.callback.call(handler, response)
       rescue => error
-        log_error(robot, error)
+        log_error(robot, error, message)
       end
 
       private

--- a/lib/lita/handler/common.rb
+++ b/lib/lita/handler/common.rb
@@ -52,8 +52,8 @@ module Lita
         alias_method :t, :translate
 
         # Logs an error raised by a plugin.
-        def log_error(robot, error)
-          robot.config.robot.error_handler.call(error)
+        def log_error(robot, error, message)
+          robot.config.robot.error_handler.call(error, message)
           robot.logger.error I18n.t(
             "lita.handler.exception",
             handler: name,


### PR DESCRIPTION
In the error handler, it would be useful to know what chat message caused the exception.
If maintainers :+1: the proposal/API, I'll add the test coverage quickly.

/cc @jimmycuadra