### PR TITLE
Add lita_config.rb to gitignore

### DIFF
--- a/templates/plugin/gitignore
+++ b/templates/plugin/gitignore
@@ -9,6 +9,7 @@ _yardoc
 coverage
 doc/
 lib/bundler/man
+lita_config.rb
 pkg
 rdoc
 spec/reports


### PR DESCRIPTION
Ignore lita_config.rb, when developing plugin.