### PR TITLE
Add support for passing a Proc to routes

### DIFF
--- a/lib/lita/handler/chat_router.rb
+++ b/lib/lita/handler/chat_router.rb
@@ -31,7 +31,9 @@ module Lita
 
       # @overload route(pattern, method_name, **options)
       #   Creates a chat route.
-      #   @param pattern [Regexp] A regular expression to match incoming messages against.
+      #   @param pattern [Regexp, Proc] Either a regular expression to match incoming messages
+      #     against, or a Proc that will be called in the context of the handler with the message,
+      #     and should return a boolean indicating whether that message matches the route
       #   @param method_name [Symbol, String] The name of the instance method to trigger.
       #   @param command [Boolean] Whether or not the message must be directed at the robot.
       #   @param restrict_to [Array<Symbol, String>, nil] An optional list of authorization
@@ -41,7 +43,9 @@ module Lita
       #   @return [void]
       # @overload route(pattern, **options)
       #   Creates a chat route.
-      #   @param pattern [Regexp] A regular expression to match incoming messages against.
+      #   @param pattern [Regexp, Proc] Either a regular expression to match incoming messages
+      #     against, or a Proc that will be called in the context of the handler with the message,
+      #     and should return a boolean indicating whether that message matches the route
       #   @param command [Boolean] Whether or not the message must be directed at the robot.
       #   @param restrict_to [Array<Symbol, String>, nil] An optional list of authorization
       #     groups the user must be in to trigger the route.
@@ -76,8 +80,9 @@ module Lita
       # @param message [Message] The incoming message.
       # @return [Boolean] Whether or not the message matched any routes.
       def dispatch(robot, message)
+        handler = new(robot)
         routes.map do |route|
-          next unless route_applies?(route, message, robot)
+          next unless route_applies?(handler, route, message, robot)
           log_dispatch(robot, route)
           robot.trigger(
             :message_dispatched,
@@ -86,7 +91,7 @@ module Lita
             message: message,
             robot: robot
           )
-          dispatch_to_route(route, robot, message)
+          dispatch_to_route(handler, route, robot, message)
           true
         end.any?
       end
@@ -97,10 +102,9 @@ module Lita
       # @param message [Message] The incoming message.
       # @return [void]
       # @since 3.3.0
-      def dispatch_to_route(route, robot, message)
+      def dispatch_to_route(handler, route, robot, message)
         response = Response.new(message, route.pattern)
         robot.hooks[:trigger_route].each { |hook| hook.call(response: response, route: route) }
-        handler = new(robot)
         route.callback.call(handler, response)
       rescue => error
         log_error(robot, error)
@@ -118,8 +122,8 @@ module Lita
       end
 
       # Determines whether or not an incoming messages should trigger a route.
-      def route_applies?(route, message, robot)
-        RouteValidator.new(self, route, message, robot).call
+      def route_applies?(handler, route, message, robot)
+        RouteValidator.new(handler, route, message, robot).call
       end
 
       # Logs the dispatch of message.

--- a/spec/lita/handler/chat_router_spec.rb
+++ b/spec/lita/handler/chat_router_spec.rb
@@ -11,6 +11,8 @@ handler = Class.new do
   route(/command/, :command, command: true)
   route(/admin/, :admin, restrict_to: :admins)
   route(/error/, :error)
+  route(->(message) { message.body == "proc route" }, :trigger_proc_route)
+  route(:symbol_route?, :trigger_symbol_route)
   route(/validate route hook/, :validate_route_hook, code_word: true)
   route(/trigger route hook/, :trigger_route_hook, custom_data: "trigger route hook")
 
@@ -28,6 +30,18 @@ handler = Class.new do
 
   def error(_response)
     raise
+  end
+
+  def symbol_route?(message)
+    message.body == "symbol route"
+  end
+
+  def trigger_proc_route(response)
+    response.reply("trigger proc route")
+  end
+
+  def trigger_symbol_route(response)
+    response.reply("trigger symbol route")
   end
 
   def validate_route_hook(response)
@@ -48,6 +62,16 @@ describe handler, lita_handler: true do
     it "routes a matching message to the supplied method" do
       send_message("message")
       expect(replies.last).to eq("message")
+    end
+
+    it "routes messages satisfying a proc to the supplied method" do
+      send_message("proc route")
+      expect(replies.last).to eq("trigger proc route")
+    end
+
+    it "routes messages satisfying a named method to the supplied method" do
+      send_message("symbol route")
+      expect(replies.last).to eq("trigger symbol route")
     end
 
     it "routes a matching message even if addressed to the robot" do


### PR DESCRIPTION
Add support for passing a Proc to routes instead of a regular
expression for matching - this proc will then be called with the message
in the context of the handler object and should return a boolean
indicating whether the route matches or not.

This allows for dynamically defined routing, plus support for
configuring things like command names and prefixes, which is useful as
plugin configuration is only available on a handler instance, not the
singleton.

Probably addresses most of what #100 is asking for
