### PR TITLE
Trigger :message_received whenever robot.receive is called

### DIFF
--- a/lib/lita/robot.rb
+++ b/lib/lita/robot.rb
@@ -108,6 +108,8 @@ module Lita
     # @param message [Message] The incoming message.
     # @return [void]
     def receive(message)
+      trigger(:message_received, message: message)
+
       matched = handlers.map do |handler|
         next unless handler.respond_to?(:dispatch)
 

--- a/spec/lita/handler/chat_router_spec.rb
+++ b/spec/lita/handler/chat_router_spec.rb
@@ -113,6 +113,7 @@ describe handler, lita_handler: true do
     end
 
     it "triggers a message_dispatched event" do
+      expect(robot).to receive(:trigger).with(:message_received, anything)
       expect(robot).to receive(:trigger).with(:message_dispatched, anything)
       send_message("message")
     end


### PR DESCRIPTION
Certain handlers use the chat route regex `/./` to permissively trigger
a method and evaluate some sort of conditional logic therein. This
effectively means that `:unhandled_message` is never triggered, which
breaks functionality like invalid command logging in lita-metrics. With
this change, plugin authors will no longer have to use the permissive
regex as a workaround. Please see the following for an example:
https://github.com/tristaneuan/lita-google-translate/pull/1