### PR TITLE
Add a configurable list of users to ignore

### DIFF
--- a/lib/lita/default_configuration.rb
+++ b/lib/lita/default_configuration.rb
@@ -85,6 +85,7 @@ module Lita
         config :mention_name, type: String
         config :alias, type: String
         config :adapter, types: [String, Symbol], default: :shell
+        config :ignore, type: Array, default: []
         config :locale, types: [String, Symbol], default: I18n.locale
         config :log_level, types: [String, Symbol], default: :info do
           validate do |value|

--- a/lib/lita/route_validator.rb
+++ b/lib/lita/route_validator.rb
@@ -29,7 +29,7 @@ module Lita
     # @return [Boolean] Whether or not the route should be triggered.
     def call
       return unless command_satisfied?(route, message)
-      return if from_self?(message, robot)
+      return if ignore?(message, robot)
       return unless matches_pattern?(route, message)
       unless authorized?(robot, message.user, route.required_groups)
         robot.trigger(
@@ -55,6 +55,18 @@ module Lita
     # Messages from self should be ignored to prevent infinite loops
     def from_self?(message, robot)
       message.user.name == robot.name
+    end
+
+    # Messages from users specified in the configuration should be ignored
+    def from_ignored_user?(message, robot)
+      robot.config.robot.ignore.include?(message.user.id) ||
+        robot.config.robot.ignore.include?(message.user.mention_name) ||
+        robot.config.robot.ignore.include?(message.user.name)
+    end
+
+    # Check whether the message should be ignored
+    def ignore?(message, robot)
+      from_self?(message, robot) || from_ignored_user?(message, robot)
     end
 
     # Message must match the pattern

--- a/spec/lita/default_configuration_spec.rb
+++ b/spec/lita/default_configuration_spec.rb
@@ -171,6 +171,10 @@ describe Lita::DefaultConfiguration, lita: true do
       expect(config.robot.adapter).to eq(:hipchat)
     end
 
+    it "has a default ignore list" do
+      expect(config.robot.ignore).to eq([])
+    end
+
     it "has a default locale" do
       expect(config.robot.locale).to eq(I18n.locale)
     end

--- a/spec/lita/handler/chat_router_spec.rb
+++ b/spec/lita/handler/chat_router_spec.rb
@@ -95,6 +95,34 @@ describe handler, lita_handler: true do
       expect(replies).to be_empty
     end
 
+    context "when an ignore list is specified in the configuration" do
+      let(:jimmy) do
+        instance_double("Lita::User", id: 0,
+                                      mention_name: "jimmy",
+                                      name: "Jimmy")
+      end
+
+      let(:mitch) do
+        instance_double("Lita::User", id: 1,
+                                      mention_name: "mitch",
+                                      name: "Mitch")
+      end
+
+      before do
+        allow(robot.config.robot).to receive(:ignore).and_return(["Jimmy"])
+      end
+
+      it "ignores users on the list" do
+        send_message("message", as: jimmy)
+        expect(replies).to be_empty
+      end
+
+      it "does not ignore users absent from the list" do
+        send_message("message", as: mitch)
+        expect(replies.last).to eq("message")
+      end
+    end
+
     it "allows route callbacks to be provided as blocks" do
       send_message("block")
       expect(replies.last).to eq("block")


### PR DESCRIPTION
This adds a configuration option in which users to be ignored by the bot
may be specified by ID, name, or mention name, preventing the
possibility of an infinite loop in a chat channel where multiple bot
users are present.
