### PR TITLE
Added a `validate` CLI command to load an test config for scripting

### DIFF
--- a/lib/lita.rb
+++ b/lib/lita.rb
@@ -29,16 +29,23 @@ module Lita
     # environment variable LITA_GLOBAL_LOG_LEVEL set to one of the standard log level names.
     attr_accessor :logger
 
-    # Loads user configuration and starts the robot.
+    # Loads user configuration.
     # @param config_path [String] The path to the user configuration file.
     # @return [void]
-    def run(config_path = nil)
+    def load_config(config_path = nil)
       hooks[:before_run].each { |hook| hook.call(config_path: config_path) }
       ConfigurationBuilder.load_user_config(config_path)
       ConfigurationBuilder.freeze_config(config)
       ConfigurationValidator.new(self).call
       hooks[:config_finalized].each { |hook| hook.call(config_path: config_path) }
       self.locale = config.robot.locale
+    end
+
+    # Loads user configuration and starts the robot.
+    # @param config_path [String] The path to the user configuration file.
+    # @return [void]
+    def run(config_path = nil)
+      load_config(config_path)
       Robot.new.run
     end
 

--- a/lib/lita/cli.rb
+++ b/lib/lita/cli.rb
@@ -117,6 +117,29 @@ module Lita
     end
     map %w(-v --version) => :version
 
+    desc "validate", "Verifies if lita is correctly configured"
+    option :config,
+      aliases: "-c",
+      banner: "PATH",
+      default: File.expand_path("lita_config.rb", Dir.pwd),
+      desc: "Path to the configuration file to use"
+    # Outputs detailed stacktrace when there is a problem or exit 0 when OK.
+    # You can use this as a pre-check script for any automation
+    # @return [void]
+    def validate
+      check_ruby_verison
+      check_default_handlers
+
+      begin
+        Bundler.require
+      rescue Bundler::GemfileNotFound
+        say I18n.t("lita.cli.no_gemfile_warning"), :red
+        abort
+      end
+
+      Lita.load_config(options[:config])
+    end
+
     private
 
     def check_ruby_verison


### PR DESCRIPTION
This will add a special command that will do most of the boot-up process
except it will not "run", but exit back to the shell.

If there are any issues with your configuration, it will fail exactly
like when you execute with `lita start`.

The motivation came from the need to check before deploy, so I can automate a few things on my workflow. This will also be a good fit for docker images or anything that does continuous deployment.

If you need any change or additional documentation, please ping me. 