### PR TITLE
Improve build: use newer JRuby, enable build on docker and add GitLab CI support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,60 @@
+# Cache gems in between builds
+cache:
+  paths:
+     - vendor
+
+variables:
+  LANG: "C.UTF-8"
+  REDIS_HOST: "redis"
+  REDIS_PORT: "6379"
+
+.test-template: &test-common
+  services:
+    - redis:latest
+  before_script:
+    - gem update --system --no-document
+    - gem install bundler --no-ri --no-rdoc
+    - bundle install -j $(nproc) --path vendor --retry 3
+
+test:2.0:
+  image: "ruby:2.0"
+  <<: *test-common
+  script:
+    - bundle exec rake
+
+test:2.1:
+  image: "ruby:2.1"
+  <<: *test-common
+  script:
+    - bundle exec rake
+
+test:2.2:
+  image: "ruby:2.2"
+  <<: *test-common
+  script:
+    - bundle exec rake
+
+test:2.3:
+  image: "ruby:2.3"
+  <<: *test-common
+  script:
+    - bundle exec rake
+
+test:jruby-9.1:
+  image: "jruby:9.1"
+  services:
+    - redis:latest
+  before_script:
+    - jgem update --system --no-document
+    - jgem install bundler --no-ri --no-rdoc
+    - bundle install -j $(nproc) --path vendor --retry 3
+  script:
+    - bundle exec rake
+  allow_failure: true
+
+test:rubinius-latest:
+  image: "rubinius/docker:latest"
+  <<: *test-common
+  script:
+    - bundle exec rake
+  allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ variables:
   services:
     - redis:latest
   before_script:
+    - apt-get update && apt-get install -y --quiet haveged && service haveged start && service haveged status
     - gem update --system --no-document
     - gem install bundler --no-ri --no-rdoc
     - bundle install -j $(nproc) --path vendor --retry 3
@@ -45,6 +46,7 @@ test:jruby-9.1:
   services:
     - redis:latest
   before_script:
+    - apt-get update && apt-get install -y --quiet haveged
     - jgem update --system --no-document
     - jgem install bundler --no-ri --no-rdoc
     - bundle install -j $(nproc) --path vendor --retry 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - jruby-9.0.0.0
+  - jruby-9.1.2.0
   - rbx-2
 matrix:
   allow_failures:
-    - rvm: jruby-9.0.0.0
+    - rvm: jruby-9.1.2.0
     - rvm: rbx-2
   fast_finish: true
 script: bundle exec rake

--- a/lib/lita/default_configuration.rb
+++ b/lib/lita/default_configuration.rb
@@ -75,7 +75,11 @@ module Lita
 
     # Builds config.redis
     def redis_config
-      root.config :redis, type: Hash, default: {}
+      # Overrides Redis host/port defined by ENVIRONMENT variables
+      default = {}
+      default[:host] = ENV["REDIS_HOST"] if ENV["REDIS_HOST"]
+      default[:port] = ENV["REDIS_PORT"] if ENV["REDIS_PORT"]
+      root.config :redis, type: Hash, default: default
     end
 
     # Builds config.robot

--- a/spec/lita/default_configuration_spec.rb
+++ b/spec/lita/default_configuration_spec.rb
@@ -117,8 +117,27 @@ describe Lita::DefaultConfiguration, lita: true do
   end
 
   describe "redis config" do
-    it "has empty default options" do
-      expect(config.redis).to eq({})
+    before do
+      allow(ENV).to receive(:[]).with("REDIS_HOST") { nil }
+      allow(ENV).to receive(:[]).with("REDIS_PORT") { nil }
+    end
+
+    context "with no specific environmental variables" do
+      it "has empty default options" do
+        expect(config.redis).to eq({})
+      end
+    end
+
+    context "with specific environmental variables" do
+      it "defines a default redis host based on REDIS_HOST env variable" do
+        allow(ENV).to receive(:[]).with("REDIS_HOST") { "myredis" }
+        expect(config.redis).to eq(host: "myredis")
+      end
+
+      it "defines a default redis port based on REDIS_PORT env variable" do
+        allow(ENV).to receive(:[]).with("REDIS_PORT") { "6380" }
+        expect(config.redis).to eq(port: "6380")
+      end
     end
 
     it "can set options" do


### PR DESCRIPTION
This pull request, updates JRuby version to a more recent one that will actually build and pass the specs.

It also provides an alternative to redefine Redis host and port for use during `test` execution phase.

I've tried many alternatives to make this possible, but neither worked, this was the closest I got.

It also adds support for building with GitLab CI (you can see it building here: https://gitlab.com/brodock/lita/pipelines/3767259)

To use GitLab CI, you have to host the repository there (this can be done by mirroring it easily using the import tool). 

This will fix #184
