### PR TITLE
Add a command line parameter to specify additional loadable Bundler group

### DIFF
--- a/lib/lita/cli.rb
+++ b/lib/lita/cli.rb
@@ -55,6 +55,11 @@ module Lita
       default: false,
       desc: "Kill existing Lita processes when starting the daemon",
       type: :boolean
+    option :load_group,
+      aliases: "-g",
+      banner: "GROUP",
+      default: nil,
+      desc: "Additional Bundler group to load automatically"
     # Starts Lita.
     # @return [void]
     def start
@@ -62,7 +67,9 @@ module Lita
       check_default_handlers
 
       begin
-        Bundler.require
+        groups = [:default]
+        groups << options[:load_group].to_sym if options[:load_group]
+        Bundler.require(groups)
       rescue Bundler::GemfileNotFound
         say I18n.t("lita.cli.no_gemfile_warning"), :red
         abort


### PR DESCRIPTION
In a Lita environment with many plugins loaded in production, we found it useful to be able to specify a small subset of plugins for development using the same Gemfile, as in the following example. This lets developers focus on particular plugins or combinations of them, while not requiring the rest of plugins to be loaded and with minimal changes between developer and production environments.

For the production environment, we need to be able to tell Lita to load gems from a non-default Bundler group, which this change enables.

```
source 'https://rubygems.org'

# Core bot and adapter
gem 'lita'
gem 'lita-slack'

# Extensions
gem 'lita-confirmation', git: 'git@github.com:maxvt/lita-confirmation'

# Move the plugins/handlers you would like to work on from the production group here.
# It is often very convenient to clone them under the repo and use the local
# version, like this:
# gem 'lita-my-plugin', path: 'lita-my-plugin'

# We enable all of these handlers in production.
# For development, pick and choose the ones you want--
# many will require configuration keys and some might have dependencies
# that will require manual setup
group :production do
  gem 'lita-github'
  gem 'lita-jira'
  gem 'lita-wikipedia'
  ...
end

group :development do
  gem 'foreman'
  gem 'pry'
end
```
