### PR TITLE
Add restricted_handlers group list config

### DIFF
--- a/lib/lita/default_configuration.rb
+++ b/lib/lita/default_configuration.rb
@@ -102,6 +102,7 @@ module Lita
             "must respond to #call" unless value.respond_to?(:call)
           end
         end
+        config :restricted_handlers, default: {}
         config :features, default: [] do
           validate do |value|
             if value.respond_to?(:each)

--- a/lib/lita/route_validator.rb
+++ b/lib/lita/route_validator.rb
@@ -71,6 +71,8 @@ module Lita
 
     # User must be in auth group if route is restricted.
     def authorized?(robot, user, required_groups)
+      default_required_groups = robot.config.robot.restricted_handlers[@handler.namespace]
+      required_groups ||= default_required_groups
       required_groups.nil? || required_groups.any? do |group|
         robot.auth.user_in_group?(user, group)
       end


### PR DESCRIPTION
## What
No very excited about this implementation as this is not using the restrict_to current syntax. But I didn't find a way to access the config values as part of the route class methods.

This also does not work with the help list of routes as it rewrites the same `authorized?` method

## Usage

```
config.robot.restricted_handlers = {
  "catgif" => [:important_people]
}
```

## Todo
- [ ] tests
- [ ] documentation