### PR TITLE
Address https://travis-ci.org/github/litaio/lita/jobs/631295228#L684

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 cache: "bundler"
 matrix:
   include:
-    - rvm: "2.6"
+    - rvm: "2.7"
       env: "CC_TEST_REPORTER_ID=505b5e2a819ce1ad685558da73ff1dedc6bac6aaa04ab593a02ac48a5303d4fd"
     - rvm: "jruby-9"
   allow_failures:


### PR DESCRIPTION
# Context

I'd like to be able to update our chatbot to Lita 5.0 but there are some dependency issues. I cloned this repository in order to address them but I saw that the main branch currently fails CI.

We need to install Ruby 2.7 to test against it.

# Change

Replace Ruby 2.6 with 2.7 in the Travis configuration.

# Confirmation

`bundle exec rake` runs successfully locally.

