### PR TITLE
Upgrade Faraday and Thor Dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 cache: "bundler"
 matrix:
   include:
-    - rvm: "2.6"
+    - rvm: "2.7"
       env: "CC_TEST_REPORTER_ID=505b5e2a819ce1ad685558da73ff1dedc6bac6aaa04ab593a02ac48a5303d4fd"
     - rvm: "jruby-9"
   allow_failures:

--- a/lita.gemspec
+++ b/lita.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rack", "~> 2.0"
   spec.add_runtime_dependency "rb-readline", "~> 0.5.0"
   spec.add_runtime_dependency "redis-namespace", "~> 1.6"
-  spec.add_runtime_dependency "thor", "~> 0.20.0"
+  spec.add_runtime_dependency "thor", "~> 1.0"
 
   spec.add_development_dependency "rack-test", "~> 1.1"
   spec.add_development_dependency "rake", "~> 12.3"

--- a/lita.gemspec
+++ b/lita.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency "bundler", "~> 2.0"
-  spec.add_runtime_dependency "faraday", "~> 0.15.0"
+  spec.add_runtime_dependency "faraday", "~> 1.0"
   spec.add_runtime_dependency "http_router", "~> 0.11.0"
   spec.add_runtime_dependency "i18n", "~> 1.6"
   spec.add_runtime_dependency "ice_nine", "~> 0.11.0"


### PR DESCRIPTION
# Context

We recently ran `bundle update` on our Lita instance to address CVE-2020-8184 and CVE-2020-8161.

The latest Lita version release is 4.7.1 (2016-09-17), which requires Rack ">= 1.5.2", "< 2.0.0" (see litaio/lita@fda3a80) and prevents us from updating Rack to version `2.1.4` or later to address these CVEs. 

Taking the latest version from GitHub (litaio/lita@312df73) comes with the trade-off that we have to downgrade Faraday to `0.15.4` from `1.0.1` and Thor from `1.0.1` to `0.20.3`. This version also fails CI (see build 631295227).

I'd really like to upgrade these dependencies to ensure we don't have any known vulnerabilities.

# Change

 - Incorporate #223 (which addresses https://travis-ci.org/github/litaio/lita/jobs/631295228#L684)
 - Upgrade Faraday (Changelog: https://github.com/lostisland/faraday/releases)
 - Upgrade Thor (Changelog: https://github.com/erikhuda/thor/blob/master/CHANGELOG.md )

# Confirmation

`bundle exec rake` runs successfully locally.