### PR TITLE
chore: Update rspec require path to rspec/core

### DIFF
--- a/lib/lita/rspec.rb
+++ b/lib/lita/rspec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 begin
-  require "rspec"
+  require "rspec/core"
   require "rspec/expectations"
   require "rspec/mocks"
 rescue LoadError


### PR DESCRIPTION
## Context
I try to write RSpec through `require "lita/rspec"`
but run rspec give errors 

```
Lita::RSpec requires both RSpec::Mocks and RSpec::Expectations.
```

## Change
Replace `require "rspec"` with `require "rspec/core"`

## Confirmation
`bundle exec rspec` runs successfully locally.