### PR TITLE
make Redis namespace configurable

### DIFF
--- a/lib/lita.rb
+++ b/lib/lita.rb
@@ -14,9 +14,6 @@ require_relative "lita/robot"
 # The main namespace for Lita. Provides a global registry of adapters and
 # handlers, as well as global configuration, logger, and Redis store.
 module Lita
-  # The base Redis namespace for all Lita data.
-  REDIS_NAMESPACE = "lita"
-
   class << self
     include Registry::Mixins
 

--- a/lib/lita/default_configuration.rb
+++ b/lib/lita/default_configuration.rb
@@ -11,6 +11,9 @@ module Lita
     # Valid levels for Lita's logger.
     LOG_LEVELS = %w[debug info warn error fatal].freeze
 
+    # The base Redis namespace for all Lita data.
+    REDIS_NAMESPACE = "lita"
+
     # A {Registry} to extract configuration for plugins from.
     # @return [Registry] The registry.
     attr_reader :registry
@@ -87,6 +90,7 @@ module Lita
         config :alias, type: String
         config :adapter, types: [String, Symbol], default: :shell
         config :locale, types: [String, Symbol], default: I18n.locale
+        config :redis_namespace, types: String, default: REDIS_NAMESPACE
         config :log_level, types: [String, Symbol], default: :info do
           validate do |value|
             unless LOG_LEVELS.include?(value.to_s.downcase.strip)

--- a/lib/lita/registry.rb
+++ b/lib/lita/registry.rb
@@ -62,7 +62,7 @@ module Lita
       def redis
         @redis ||= begin
           redis = Redis.new(config.redis)
-          Redis::Namespace.new(REDIS_NAMESPACE, redis: redis).tap(&:ping)
+          Redis::Namespace.new(config.robot.redis_namespace, redis: redis).tap(&:ping)
         end
       rescue Redis::BaseError => e
         if Lita.test_mode?

--- a/lib/lita/rspec.rb
+++ b/lib/lita/rspec.rb
@@ -31,7 +31,7 @@ module Lita
           let(:registry) { Registry.new }
 
           before do
-            stub_const("Lita::REDIS_NAMESPACE", "lita.test")
+            stub_const("Lita::DefaultConfiguration::REDIS_NAMESPACE", "lita.test")
             keys = Lita.redis.keys("*")
             Lita.redis.del(keys) unless keys.empty?
           end

--- a/spec/lita/default_configuration_spec.rb
+++ b/spec/lita/default_configuration_spec.rb
@@ -193,6 +193,16 @@ describe Lita::DefaultConfiguration, lita: true do
       expect(config.robot.log_level).to eq(:debug)
     end
 
+    it "has a default redis namespace" do
+      expect(config.robot.redis_namespace).to eq(Lita::DefaultConfiguration::REDIS_NAMESPACE)
+    end
+
+    it "can set a redis namespace" do
+      config.robot.redis_namespace = "mylitabot"
+
+      expect(config.robot.redis_namespace).to eq("mylitabot")
+    end
+
     it "allows strings and mixed case as log levels" do
       expect { config.robot.log_level = "dEbUg" }.not_to raise_error
     end


### PR DESCRIPTION
* move the `REDIS_NAMESPACE` constant into `Lita::DefaultConfiguration`
* expose `config.robot.redis_namespace` and use the new constant's value as its default

Fixes: #228